### PR TITLE
Added Password field to UserAccountObjectType

### DIFF
--- a/objects/User_Account_Object.xsd
+++ b/objects/User_Account_Object.xsd
@@ -59,6 +59,11 @@
 							<xs:documentation>The Username field specifies the particular username of the user account.</xs:documentation>
 						</xs:annotation>
 					</xs:element>
+					<xs:element name="Password" type="cyboxCommon:StringObjectPropertyType" minOccurs="0" maxOccurs="1">
+						<xs:annotation>
+							<xs:documentation>The Password field specifies the literal password of the user account</xs:documentation>
+						</xs:annotation>
+					</xs:element>
 					<xs:element name="User_Password_Age" type="cyboxCommon:DurationObjectPropertyType" minOccurs="0" maxOccurs="1">
 						<xs:annotation>
 							<xs:documentation>The User_Password_Age field specifies the current age of the user account's password.</xs:documentation>


### PR DESCRIPTION
This addresses #91.

Is StringObjectPropertyType appropriate for this field? Do we want to record literal passwords associated with user accounts or some sort of hashed password construct with attributes for identifying the associated hash/encryption algorithm? 
