### PR TITLE
Made @datatype attribute optional on HTTPMethodType. Closes #22

### DIFF
--- a/objects/HTTP_Session_Object.xsd
+++ b/objects/HTTP_Session_Object.xsd
@@ -601,7 +601,7 @@
 				<xs:simpleType>
 					<xs:union memberTypes="HTTPSessionObj:HTTPMethodEnum xs:string"/>
 				</xs:simpleType>
-				<xs:attribute fixed="string" name="datatype" type="cyboxCommon:DatatypeEnum" use="required">
+				<xs:attribute fixed="string" name="datatype" type="cyboxCommon:DatatypeEnum" use="optional">
 					<xs:annotation>
 						<xs:documentation>This attribute is optional and specifies the expected type for the value of the specified property.</xs:documentation>
 					</xs:annotation>


### PR DESCRIPTION
This addresses #22.
