### PR TITLE
Issue 49 (Update LinuxPackageObjectType ArchitectureTypeEnum)

### DIFF
--- a/objects/Linux_Package_Object.xsd
+++ b/objects/Linux_Package_Object.xsd
@@ -23,9 +23,9 @@
 		<xs:complexContent>
 			<xs:extension base="cyboxCommon:ObjectPropertiesType">
 				<xs:sequence>
-					<xs:element name="Architecture" type="LinuxPackageObj:ArchitectureType" minOccurs="0">
+					<xs:element name="Architecture" type="cyboxCommon:ControlledVocabularyStringType" minOccurs="0">
 						<xs:annotation>
-							<xs:documentation>The Architecture field specifies the architecture for which the package was built.</xs:documentation>
+							<xs:documentation>The Architecture field specifies the architecture for which the package was built. Examples include "i386", "armhf", "ppc", "sparc", "x86_64", "mips", "noarch", etc. </xs:documentation>
 						</xs:annotation>
 					</xs:element>
 					<xs:element name="Category" type="cyboxCommon:StringObjectPropertyType" minOccurs="0">
@@ -72,48 +72,4 @@
 			</xs:extension>
 		</xs:complexContent>
 	</xs:complexType>
-	<xs:complexType name="ArchitectureType">
-		<xs:annotation>
-			<xs:documentation>ArchitectureType specifies CPU architecture types, via a union of the ArchitectureTypeEnum type and the atomic xs:string type. Its base type is the CybOX Core BaseObjectPropertyType, for permitting complex (i.e. regular-expression based) specifications.</xs:documentation>
-		</xs:annotation>
-		<xs:simpleContent>
-			<xs:restriction base="cyboxCommon:BaseObjectPropertyType">
-				<xs:simpleType>
-					<xs:union memberTypes="LinuxPackageObj:ArchitectureTypeEnum xs:string"/>
-				</xs:simpleType>
-				<xs:attribute name="datatype" type="cyboxCommon:DatatypeEnum" fixed="string">
-					<xs:annotation>
-						<xs:documentation>This attribute is optional and specifies the expected type for the value of the specified property.</xs:documentation>
-					</xs:annotation>
-				</xs:attribute>
-			</xs:restriction>
-		</xs:simpleContent>
-	</xs:complexType>
-	<xs:simpleType name="ArchitectureTypeEnum">
-		<xs:annotation>
-			<xs:documentation>The ArchitectureTypeEnum type is a non-exhaustive enumeration of CPU architectures.</xs:documentation>
-		</xs:annotation>
-		<xs:restriction base="xs:string">
-			<xs:enumeration value="i386">
-				<xs:annotation>
-					<xs:documentation>Indicates an i386 architecture.</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="PPC">
-				<xs:annotation>
-					<xs:documentation>Indicates an PPC architecture.</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="SPARC">
-				<xs:annotation>
-					<xs:documentation>Indicates an SPARC architecture.</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="noarch">
-				<xs:annotation>
-					<xs:documentation>Indicates no particular architecture.</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-		</xs:restriction>
-	</xs:simpleType>
 </xs:schema>


### PR DESCRIPTION
Resolves #49 

Implements the following proposal:
https://github.com/CybOXProject/schemas/wiki/Proposal:-Change-LinuxPackageObjectType-Architecture-Field-To-ControlledVocabularyStringType

This pull request does the following:
- Sets type of LinuxPackageObjectType's Architecture field to ControlledVocabularyStringType
- Removes ArchitectureType
- Removes ArchitectureTypeEnum
