### PR TITLE
Added URL History Object

### DIFF
--- a/objects/URL_History_Object.xsd
+++ b/objects/URL_History_Object.xsd
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
-<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:DomainNameObj="http://cybox.mitre.org/objects#DomainNameObject-1" xmlns:URIObj="http://cybox.mitre.org/objects#URIObject-2" xmlns:URLHistoryObj="http://cybox.mitre.org/objects#URLHistoryObject-1" xmlns:cyboxCommon="http://cybox.mitre.org/common-2" targetNamespace="http://cybox.mitre.org/objects#URLHistoryObject-1" elementFormDefault="qualified" attributeFormDefault="unqualified" version="1.0.0">
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:HostnameObj="http://cybox.mitre.org/objects#HostnameObject-1" xmlns:URIObj="http://cybox.mitre.org/objects#URIObject-2" xmlns:URLHistoryObj="http://cybox.mitre.org/objects#URLHistoryObject-1" xmlns:cyboxCommon="http://cybox.mitre.org/common-2" targetNamespace="http://cybox.mitre.org/objects#URLHistoryObject-1" elementFormDefault="qualified" attributeFormDefault="unqualified" version="1.0">
 	<xs:annotation>
 		<xs:documentation>This schema was originally developed by The MITRE Corporation. The CybOX XML Schema implementation is maintained by The MITRE Corporation and developed by the open CybOX Community. For more information, including how to get involved in the effort and how to submit change requests, please visit the CybOX website at http://cybox.mitre.org. </xs:documentation>
 		<xs:appinfo>
 			<schema>URL_History_Object</schema>
-			<version>1.0.0</version>
+			<version>1.0</version>
 			<date>12/4/2013 9:00:00 AM</date>
 			<short_description>The following specifies the fields and types that compose this defined CybOX Object type. Each defined object is an extension of the abstract ObjectPropertiesType, defined in CybOX Common. For more information on this extension mechanism, please see the CybOX Specification. This document is intended for developers and assumes some familiarity with XML. </short_description>
 			<terms_of_use>Copyright (c) 2013, The MITRE Corporation. All rights reserved. The contents of this file are subject to the terms of the CybOX License located at http://cybox.mitre.org/about/termsofuse.html. See the CybOX License for the specific language governing permissions and limitations for use of this schema. When distributing copies of the CybOX Schema, this license header must be included. </terms_of_use>
@@ -12,7 +12,7 @@
 	</xs:annotation>
 	<xs:import namespace="http://cybox.mitre.org/common-2" schemaLocation="../cybox_common.xsd"/>
 	<xs:import namespace="http://cybox.mitre.org/objects#URIObject-2" schemaLocation="URI_Object.xsd"/>
-	<xs:import namespace="http://cybox.mitre.org/objects#DomainNameObject-1" schemaLocation="Domain_Name_Object.xsd"/>
+	<xs:import namespace="http://cybox.mitre.org/objects#HostnameObject-1" schemaLocation="Hostname_Object.xsd"/>
 	<xs:element name="URL_History" type="URLHistoryObj:URLHistoryObjectType">
 		<xs:annotation>
 			<xs:documentation>The URL_History object is intended to characterize the stored URL history of a particular web browser.</xs:documentation>
@@ -49,7 +49,7 @@
 					<xs:documentation>The URL field specifies the URL that the URL history entry points to. It uses the URIObjectType from the imported CybOX URI Object.</xs:documentation>
 				</xs:annotation>
 			</xs:element>
-			<xs:element minOccurs="0" name="Hostname" type="DomainNameObj:DomainNameObjectType">
+			<xs:element minOccurs="0" name="Hostname" type="HostnameObj:HostnameObjectType">
 				<xs:annotation>
 					<xs:documentation>The Hostname field specifies the hostname portion of the URL that the URL history entry points to (captured in the URL field).</xs:documentation>
 				</xs:annotation>


### PR DESCRIPTION
Added a URL History Object which should be capable of capturing the URL history entries across several entries. I've looked at IE, FireFox/Mozilla, Chrome, and Safari - it should be capable of accurately characterizing the URL history entries for each. 

This should close #45.
