### PR TITLE
Added Firmware_Version and System_Details Fields to Device Object

### DIFF
--- a/objects/Device_Object.xsd
+++ b/objects/Device_Object.xsd
@@ -55,7 +55,7 @@
 					</xs:element>
 					<xs:element minOccurs="0" name="System_Details" type="cyboxCommon:ObjectPropertiesType">
 						<xs:annotation>
-							<xs:documentation>The System_Details field captures the details of the system that may be present on the device. It uses the ObjectProperties type from CybOX Common to allow for the usage of various object for representing the system.</xs:documentation>
+							<xs:documentation>The System_Details field captures the details of the system that may be present on the device. It uses the abstract ObjectPropertiesType which permits the specification of any Object; however, it is strongly recommended that the System Object or one of its subtypes be used in this context.</xs:documentation>
 						</xs:annotation>
 					</xs:element>
 				</xs:sequence>


### PR DESCRIPTION
Added the Firmware_Version and System_Details fields to the DeviceObjectType in the Device Object for capturing the version of the firmware running on the device and the details of a system present on the device on the device, respectively. The System_Details field uses the ObjectPropertiesType to allow for the plugging in of any System Object, including the current System Object and Windows System Object.

This should close #206.
