### PR TITLE
Removed Type from PESectionType in Windows Executable File Object and removed associated Types

### DIFF
--- a/objects/Win_Executable_File_Object.xsd
+++ b/objects/Win_Executable_File_Object.xsd
@@ -453,11 +453,6 @@
 					<xs:documentation>The Header_Hashes field is used to include any hash values computed using the header of the specified PE binary section as input.</xs:documentation>
 				</xs:annotation>
 			</xs:element>
-			<xs:element name="Type" type="WinExecutableFileObj:SectionType" minOccurs="0">
-				<xs:annotation>
-					<xs:documentation>Specifies the type of the section.</xs:documentation>
-				</xs:annotation>
-			</xs:element>
 		</xs:sequence>
 	</xs:complexType>
 	<xs:complexType name="PEDataDirectoryStructType">
@@ -759,23 +754,6 @@
 			</xs:restriction>
 		</xs:simpleContent>
 	</xs:complexType>
-	<xs:complexType name="SectionType">
-		<xs:annotation>
-			<xs:documentation>The SectionType specifies PE section types via a union of the SectionTypeEnum type and the atomic xs:string type. Its base type is the CybOX Core BaseObjectPropertyType, for permitting complex (i.e. regular-expression based) specifications.</xs:documentation>
-		</xs:annotation>
-		<xs:simpleContent>
-			<xs:restriction base="cyboxCommon:BaseObjectPropertyType">
-				<xs:simpleType>
-					<xs:union memberTypes="WinExecutableFileObj:SectionTypeEnum xs:string"/>
-				</xs:simpleType>
-				<xs:attribute name="datatype" type="cyboxCommon:DatatypeEnum" fixed="string">
-					<xs:annotation>
-						<xs:documentation>This attribute is optional and specifies the expected type for the value of the specified property.</xs:documentation>
-					</xs:annotation>
-				</xs:attribute>
-			</xs:restriction>
-		</xs:simpleContent>
-	</xs:complexType>
 	<xs:complexType name="PEOptionalHeaderType">
 		<xs:annotation>
 			<xs:documentation>The PEOptionalHeaderType type describes the PE Optional Header structure. Additional computed metadata, e.g., hashes of the header, are also included.</xs:documentation>
@@ -1057,58 +1035,6 @@
 			</xs:element>
 		</xs:sequence>
 	</xs:complexType>
-	<xs:simpleType name="SectionTypeEnum">
-		<xs:annotation>
-			<xs:documentation>The SectionTypeEnum enumerates the types of PE sections in an executable. See http://www.silurian.com/inspect/peformat.htm for more information. These sections can be viewed in a Disassembler, such as IDA and more specifically in the freeware CFF Explorer.</xs:documentation>
-		</xs:annotation>
-		<xs:restriction base="xs:string">
-			<xs:enumeration value="Text">
-				<xs:annotation>
-					<xs:documentation>Denoted by .text, this specifies the main program code--usually execute and read access only.</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="Data">
-				<xs:annotation>
-					<xs:documentation>Denoted by .data, this specifies main initialized data code that is used by the program.</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="Resource">
-				<xs:annotation>
-					<xs:documentation>Denoted by .rsrc, this specifies Windows Resource data.</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="ReadonlyData">
-				<xs:annotation>
-					<xs:documentation>Denoted by .rdata, this specifies read only data.</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="Relocations">
-				<xs:annotation>
-					<xs:documentation>Denoted by .reloc, this specifies base relocations.</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="Debug">
-				<xs:annotation>
-					<xs:documentation>Denoted by .debug, this specifies debug information.</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="IData">
-				<xs:annotation>
-					<xs:documentation>Denoted by .idata, this specifies imported function data.</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="TLS">
-				<xs:annotation>
-					<xs:documentation>Denoted by .tls, this specifies Thread Local Storage. Data is private to each thread.</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="CRT">
-				<xs:annotation>
-					<xs:documentation>Denoted by .CRT, this specifies data reserved for the C Run-Time library.</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-		</xs:restriction>
-	</xs:simpleType>
 	<xs:simpleType name="SubsystemTypeEnum">
 		<xs:annotation>
 			<xs:documentation>The SubsystemTypeEnum enumerates the types of subsystems in Windows an executable can be compatible for, according to winnt.h and more specifically, the Subsystem value of the IMAGE_OPTIONAL_HEADER structure. See http://source.winehq.org/source/include/winnt.h and http://msdn.microsoft.com/en-us/library/windows/desktop/ms680339(v=vs.85).aspx for more information.</xs:documentation>


### PR DESCRIPTION
Remove the Type field from the PESectionType and the associated PESectionTypeEnum and PESectionType that were used in this field. There's no way to accurately characterize the "type" of a section in a PE file, so this field was misleading and also conflicted with the Name field in the PESectionHeaderStructType, which is a more accurate way of capturing this data.

This should close #250.
