### PR TITLE
Added ToolTypeVocab-1.1 and ToolTypeEnum-1.1 to CybOX Default Vocabularies

### DIFF
--- a/cybox_default_vocabularies.xsd
+++ b/cybox_default_vocabularies.xsd
@@ -5055,7 +5055,7 @@
 					<xs:union memberTypes="cyboxVocabs:ToolTypeEnum-1.1"/>
 				</xs:simpleType>
 				<xs:attribute name="vocab_name" type="xs:string" use="optional" fixed="CybOX Default Tool Types"/>
-				<xs:attribute name="vocab_reference" type="xs:anyURI" use="optional" fixed="http://cybox.mitre.org/XMLSchema/default_vocabularies/2.0/cybox_default_vocabularies.xsd#ToolTypeVocab-1.0"/>
+				<xs:attribute name="vocab_reference" type="xs:anyURI" use="optional" fixed="http://cybox.mitre.org/XMLSchema/default_vocabularies/2.1/cybox_default_vocabularies.xsd#ToolTypeVocab-1.1"/>
 			</xs:restriction>
 		</xs:simpleContent>
 	</xs:complexType>


### PR DESCRIPTION
Updated the existing ToolTypeVocab-1.0 and ToolTypeEnum-1.0 vocabulary for capturing types of tools capable of generating observations, based on the recent proposal and discussion. This should close #158.
