### PR TITLE
Changed minOccurs on Configuration_Settings field in ToolConfigurationType to 0

### DIFF
--- a/cybox_common.xsd
+++ b/cybox_common.xsd
@@ -439,7 +439,7 @@
 			<xs:documentation>The ToolConfigurationType characterizes the configuration for a tool used as a cyber observation source.</xs:documentation>
 		</xs:annotation>
 		<xs:sequence>
-			<xs:element name="Configuration_Settings" type="cyboxCommon:ConfigurationSettingsType">
+			<xs:element name="Configuration_Settings" type="cyboxCommon:ConfigurationSettingsType" minOccurs="0">
 				<xs:annotation>
 					<xs:documentation>This field describes the configuration settings of this tool instance.</xs:documentation>
 				</xs:annotation>


### PR DESCRIPTION
Made the Configuration_Settings field in the ToolConfigurationType (from CybOX Common) optional. This allows use of the ToolConfigurationType for capturing relevant properties (e.g. Build_Information) without having to specify any tool configuration entries. This should close #263.
