### PR TITLE
Updated annotation for Name field in RegistryValueType of Windows Registry Key Object

### DIFF
--- a/objects/Win_Registry_Key_Object.xsd
+++ b/objects/Win_Registry_Key_Object.xsd
@@ -86,7 +86,7 @@
 		<xs:sequence>
 			<xs:element name="Name" type="cyboxCommon:StringObjectPropertyType" minOccurs="0">
 				<xs:annotation>
-					<xs:documentation>The Name field specifies the name of the registry value.</xs:documentation>
+					<xs:documentation>The Name field specifies the name of the registry value. For specifying the default value in a registry key, an empty string should be used. </xs:documentation>
 				</xs:annotation>
 			</xs:element>
 			<xs:element name="Data" type="cyboxCommon:StringObjectPropertyType" minOccurs="0">


### PR DESCRIPTION
Updated the annotation for the Name field in the RegistryValueType of the Windows Registry Key Object to state how the capture the default value, via the empty string (as in OVAL). This should close #272.
