### PR TITLE
Update default_vocabularies.xsd

### DIFF
--- a/default_vocabularies.xsd
+++ b/default_vocabularies.xsd
@@ -1072,11 +1072,6 @@
 					<xs:documentation>Specifies the defined action of getting the service status.</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
-			<xs:enumeration value="Get System Global Flags">
-				<xs:annotation>
-					<xs:documentation>Specifies the defined action of getting the system global flags.</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
 			<xs:enumeration value="Get System Local Time">
 				<xs:annotation>
 					<xs:documentation>Specifies the defined action of getting the local time on a system.</xs:documentation>


### PR DESCRIPTION
removed duplicate ActionNameEnum-1.0 value "Get System Global Flags"
removed duplicate ActionNameEnum-1.1 value "Get System Global Flags"